### PR TITLE
Add published: true frontmatter (required by FDS v1.9.0)

### DIFF
--- a/content/paths/test.mdx
+++ b/content/paths/test.mdx
@@ -48,6 +48,7 @@ path:
       travel between places — and supports critical engagement with patterns of
       connection and change. To incorporate Paths into a course, please contact
       [Roopika Risam](mailto\:roopika.risam@dartmouth.edu).
+published: true
 ---
 
 Paths trace stories across time and space. Using places from the Explorers, creators can build narratives to show how people, movements, and ideas travel. This Path demonstrates how the functionality supports storytelling and serves teaching and research.

--- a/content/posts/demo-of-post-functionality.mdx
+++ b/content/posts/demo-of-post-functionality.mdx
@@ -5,6 +5,7 @@ date: 2025-10-14T04:00:00.000Z
 cardImage: >-
   https://core-data-tina-cms.s3.us-east-1.amazonaws.com/pan-african-data-content/writing-1524065_1280.jpg
 imageAlt: Words in cursive over a pattern on a maroon background
+published: true
 ---
 
 Posts bring together text, media, and visualization to tell rich, research-informed stories. They can serve as interactive essays, course materials, or research showcases, integrating everything from timelines and maps to embedded AV, media, and tables within a single, accessible narrative frame. With Rich Text and Markdown editors, Posts are easy to create. We encourage researchers who wish to create Posts to tell stories constructed from data in the Explorers and instructors who wish to incorporate Posts into a class assignment to contact [Roopika Risam](mailto\:roopika.risam@dartmouth.edu).

--- a/content/posts/the-data1-events.mdx
+++ b/content/posts/the-data1-events.mdx
@@ -5,6 +5,7 @@ date: 2025-10-10T04:00:00.000Z
 cardImage: >-
   https://core-data-tina-cms.s3.us-east-1.amazonaws.com/pan-african-data-content/data-events-cropped.png
 imageAlt: Google Sheet of events for the Pan-African Data Project
+published: true
 ---
 
 The [Events Explorer](https://www.panafricandata.org/en/search/events/) contains data for 45 of the 76 events in our dataset. Finding reputable sources for the remaining events has been a challenge, a result of the fact that documentation of Pan-Africanism can be spotty. If we have not been able to confirm at least one participant for an event, we have not made it discoverable through the Events Explorer.

--- a/content/posts/the-data2-people.mdx
+++ b/content/posts/the-data2-people.mdx
@@ -8,6 +8,7 @@ imageAlt: >-
   A map of locations associated with Amy Ashwood Garvey, followed by a bio,
   gender, notes, occupation, citations, web authorities, events, organizations,
   and places
+published: true
 ---
 
 The [People Explorer](https://www.panafricandata.org/en/search/people/) includes 1,700+ people who participated in events or organizations related to Pan-Africanism and Afro-Asian internationalism.

--- a/content/posts/the-data3-organizations.mdx
+++ b/content/posts/the-data3-organizations.mdx
@@ -5,6 +5,7 @@ date: 2025-10-10T04:00:00.000Z
 cardImage: >-
   https://core-data-tina-cms.s3.us-east-1.amazonaws.com/pan-african-data-content/negro-association-manchester-cropped.png
 imageAlt: 'Page from handwritten subscription book of the Negro Association, Manchester'
+published: true
 ---
 
 The [Organizations Explorer](https://www.panafricandata.org/en/search/organizations/) includes 43 organizations that we have been able to verify as having existed through multiple sources, even if we have not been able to identify participants. We considered leaving out the ones without known participants but recognized that surfacing their names might lead to further research that could find individuals associated with them. An additional 22 in our dataset only have one secondary source to document them.


### PR DESCRIPTION
FDS v1.9.0 filters the /api/posts and /api/paths feeds by `published: true` unconditionally, so posts and paths without the key disappear after the upgrade. This runs the migration script that ships with FDS (`scripts/migrations/v1.9.0-posts-published.mjs`) over content/posts and content/paths — it adds the key to the 5 files that lack it, preserving TinaCMS frontmatter formatting.

Part of onboarding the production site to Clerk SSO / v1.10.0 (the deploys blocked since June). Merge before the production deploy is published.